### PR TITLE
houseworksクエリにソート機能を追加

### DIFF
--- a/app/graphql/types/housework_sort_input_type.rb
+++ b/app/graphql/types/housework_sort_input_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class HouseworkSortInputType < Types::BaseInputObject
+    argument :field, String, required: true, description: "Field to sort by (title, point, created_at, updated_at)"
+    argument :direction, String, required: false, description: "Sort direction (asc or desc)", default_value: "asc"
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -53,6 +53,7 @@ module Types
     field :houseworks, [ Types::HouseworkType ], null: false do
       argument :family_id, ID, required: true, description: "ID of the family"
       argument :filter, Types::HouseworkFilterInputType, required: false, description: "Filter options"
+      argument :sort, Types::HouseworkSortInputType, required: false, description: "Sort options"
     end
 
     def housework(id:)
@@ -66,7 +67,7 @@ module Types
       housework
     end
 
-    def houseworks(family_id:, filter: nil)
+    def houseworks(family_id:, filter: nil, sort: nil)
       user = context[:current_user]
       return [] unless user
       return [] unless user.family_id == family_id
@@ -78,6 +79,18 @@ module Types
         houseworks = houseworks.where(suggested_by_id: filter[:suggested_by_id]) if filter[:suggested_by_id].present?
         houseworks = houseworks.where(point: filter[:point_min]..) if filter[:point_min].present?
         houseworks = houseworks.where(point: ..filter[:point_max]) if filter[:point_max].present?
+      end
+
+      if sort
+        field = sort[:field]
+        direction = sort[:direction] || "asc"
+
+        valid_fields = %w[title point created_at updated_at]
+        valid_directions = %w[asc desc]
+
+        if valid_fields.include?(field) && valid_directions.include?(direction)
+          houseworks = houseworks.order("#{field} #{direction}")
+        end
       end
 
       houseworks

--- a/spec/graphql/queries/housework_spec.rb
+++ b/spec/graphql/queries/housework_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
   let(:user) { create(:user, family: family) }
   let(:other_family) { create(:family) }
   let(:other_user) { create(:user, family: other_family) }
-  let!(:housework1) { create(:housework, family: family, suggested_by: user, title: '掃除', point: 10, committed: false) }
-  let!(:housework2) { create(:housework, family: family, suggested_by: user, title: '洗濯', point: 5, committed: true) }
+  let!(:housework1) { create(:housework, family: family, suggested_by: user, title: '掃除', point: 10, committed: false, created_at: 2.days.ago) }
+  let!(:housework2) { create(:housework, family: family, suggested_by: user, title: '洗濯', point: 5, committed: true, created_at: 1.day.ago) }
+  let!(:housework3) { create(:housework, family: family, suggested_by: user, title: '料理', point: 15, committed: false, created_at: 3.days.ago) }
   let!(:other_housework) { create(:housework, family: other_family, suggested_by: other_user) }
 
   def execute_query(query_string, variables: {}, context: {})
@@ -84,8 +85,8 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
   describe 'houseworks query' do
     let(:query) do
       <<~GRAPHQL
-        query($familyId: ID!, $filter: HouseworkFilterInput) {
-          houseworks(familyId: $familyId, filter: $filter) {
+        query($familyId: ID!, $filter: HouseworkFilterInput, $sort: HouseworkSortInput) {
+          houseworks(familyId: $familyId, filter: $filter, sort: $sort) {
             id
             title
             description
@@ -109,9 +110,9 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
 
         expect(result['errors']).to be_nil
         data = result['data']['houseworks']
-        expect(data.length).to eq(2)
+        expect(data.length).to eq(3)
         titles = data.map { |h| h['title'] }
-        expect(titles).to contain_exactly('掃除', '洗濯')
+        expect(titles).to contain_exactly('掃除', '洗濯', '料理')
       end
 
       context 'with committed filter' do
@@ -138,7 +139,7 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
 
           expect(result['errors']).to be_nil
           data = result['data']['houseworks']
-          expect(data.length).to eq(2)
+          expect(data.length).to eq(3)
         end
       end
 
@@ -151,9 +152,124 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
 
           expect(result['errors']).to be_nil
           data = result['data']['houseworks']
-          expect(data.length).to eq(1)
-          expect(data[0]['title']).to eq('掃除')
-          expect(data[0]['point']).to eq(10)
+          expect(data.length).to eq(2)
+          titles = data.map { |h| h['title'] }
+          expect(titles).to contain_exactly('掃除', '料理')
+        end
+      end
+
+      context 'with sort parameter' do
+        it 'sorts houseworks by title in ascending order' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'title', direction: 'asc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          titles = data.map { |h| h['title'] }
+          expect(titles).to eq([ '掃除', '料理', '洗濯' ])
+        end
+
+        it 'sorts houseworks by title in descending order' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'title', direction: 'desc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          titles = data.map { |h| h['title'] }
+          expect(titles).to eq([ '洗濯', '料理', '掃除' ])
+        end
+
+        it 'sorts houseworks by point in ascending order' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'point', direction: 'asc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          points = data.map { |h| h['point'] }
+          expect(points).to eq([ 5, 10, 15 ])
+        end
+
+        it 'sorts houseworks by point in descending order' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'point', direction: 'desc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          points = data.map { |h| h['point'] }
+          expect(points).to eq([ 15, 10, 5 ])
+        end
+
+        it 'sorts houseworks by created_at in ascending order' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'created_at', direction: 'asc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          titles = data.map { |h| h['title'] }
+          expect(titles).to eq([ '料理', '掃除', '洗濯' ])
+        end
+
+        it 'sorts houseworks by created_at in descending order' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'created_at', direction: 'desc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          titles = data.map { |h| h['title'] }
+          expect(titles).to eq([ '洗濯', '掃除', '料理' ])
+        end
+
+        it 'defaults to ascending order when direction is not specified' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'point' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+          points = data.map { |h| h['point'] }
+          expect(points).to eq([ 5, 10, 15 ])
+        end
+
+        it 'ignores invalid field names' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'invalid_field', direction: 'asc' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
+        end
+
+        it 'ignores invalid direction values' do
+          result = execute_query(query,
+            variables: { familyId: family.id, sort: { field: 'point', direction: 'invalid' } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data.length).to eq(3)
         end
       end
     end


### PR DESCRIPTION
- HouseworkSortInputTypeを新規作成
- houseworksクエリにsort引数を追加
- title, point, created_at, updated_atでのソートに対応
- ソート機能のテストケースを追加

🤖 Generated with [Claude Code](https://claude.ai/code)