### PR TITLE
houseworksテーブルのGraphQL mutationを実装 (#12)

### DIFF
--- a/app/graphql/mutations/create_housework_mutation.rb
+++ b/app/graphql/mutations/create_housework_mutation.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateHouseworkMutation < BaseMutation
+    description "Creates a new housework"
+
+    argument :title, String, required: true, description: "Title of the housework"
+    argument :description, String, required: false, description: "Description of the housework"
+    argument :schedule, String, required: false, description: "Schedule information"
+    argument :point, Integer, required: false, description: "Points for the housework (admin only)"
+    argument :committed, Boolean, required: false, description: "Whether the housework is committed (admin only)"
+
+    field :housework, Types::HouseworkType, null: true
+    field :errors, [ String ], null: false
+
+    def resolve(title:, description: nil, schedule: nil, point: nil, committed: nil)
+      current_user = context[:current_user]
+
+      unless current_user
+        return {
+          housework: nil,
+          errors: [ "You must be logged in to create housework" ]
+        }
+      end
+
+      unless current_user.family_id
+        return {
+          housework: nil,
+          errors: [ "You must be assigned to a family to create housework" ]
+        }
+      end
+
+      # Only admins can set point and committed fields
+      if (point.present? || committed.present?) && current_user.role != "admin"
+        return {
+          housework: nil,
+          errors: [ "Only administrators can set point and committed fields" ]
+        }
+      end
+
+      # Set default values for admin-only fields
+      point = 0 if point.nil?
+      committed = false if committed.nil?
+
+      housework = Housework.new(
+        family_id: current_user.family_id,
+        title: title,
+        description: description,
+        schedule: schedule,
+        suggested_by: current_user,
+        point: point,
+        committed: committed
+      )
+
+      if housework.save
+        {
+          housework: housework,
+          errors: []
+        }
+      else
+        {
+          housework: nil,
+          errors: housework.errors.full_messages
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/delete_housework_mutation.rb
+++ b/app/graphql/mutations/delete_housework_mutation.rb
@@ -35,8 +35,8 @@ module Mutations
         }
       end
 
-      # Check if housework is committed and cannot be deleted
-      if housework.committed?
+      # Check if housework is committed and cannot be deleted (except for admins)
+      if housework.committed? && current_user.role != "admin"
         return {
           success: false,
           errors: [ "Cannot delete committed housework" ]

--- a/app/graphql/mutations/delete_housework_mutation.rb
+++ b/app/graphql/mutations/delete_housework_mutation.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Mutations
+  class DeleteHouseworkMutation < BaseMutation
+    description "Deletes an existing housework (soft delete)"
+
+    argument :id, ID, required: true, description: "ID of the housework to delete"
+
+    field :success, Boolean, null: false
+    field :errors, [ String ], null: false
+
+    def resolve(id:)
+      current_user = context[:current_user]
+
+      unless current_user
+        return {
+          success: false,
+          errors: [ "You must be logged in to delete housework" ]
+        }
+      end
+
+      housework = Housework.active.find_by(id: id)
+      unless housework
+        return {
+          success: false,
+          errors: [ "Housework not found" ]
+        }
+      end
+
+      # Check if user belongs to the same family
+      unless housework.family_id == current_user.family_id
+        return {
+          success: false,
+          errors: [ "You can only delete housework from your family" ]
+        }
+      end
+
+      # Check if housework is committed and cannot be deleted
+      if housework.committed?
+        return {
+          success: false,
+          errors: [ "Cannot delete committed housework" ]
+        }
+      end
+
+      # Check authorization: owner or admin can delete
+      unless current_user.role == "admin" || housework.suggested_by_id == current_user.id
+        return {
+          success: false,
+          errors: [ "You can only delete housework you created or must be an administrator" ]
+        }
+      end
+
+      # Soft delete by setting deleted_at timestamp
+      if housework.update(deleted_at: Time.current)
+        {
+          success: true,
+          errors: []
+        }
+      else
+        {
+          success: false,
+          errors: housework.errors.full_messages
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/update_housework_mutation.rb
+++ b/app/graphql/mutations/update_housework_mutation.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Mutations
+  class UpdateHouseworkMutation < BaseMutation
+    description "Updates an existing housework"
+
+    argument :id, ID, required: true, description: "ID of the housework to update"
+    argument :title, String, required: false, description: "Title of the housework"
+    argument :description, String, required: false, description: "Description of the housework"
+    argument :schedule, String, required: false, description: "Schedule information"
+    argument :point, Integer, required: false, description: "Points for the housework (admin only)"
+    argument :committed, Boolean, required: false, description: "Whether the housework is committed (admin only)"
+
+    field :housework, Types::HouseworkType, null: true
+    field :errors, [ String ], null: false
+
+    def resolve(id:, **attributes)
+      current_user = context[:current_user]
+
+      unless current_user
+        return {
+          housework: nil,
+          errors: [ "You must be logged in to update housework" ]
+        }
+      end
+
+      housework = Housework.active.find_by(id: id)
+      unless housework
+        return {
+          housework: nil,
+          errors: [ "Housework not found" ]
+        }
+      end
+
+      # Check if user belongs to the same family
+      unless housework.family_id == current_user.family_id
+        return {
+          housework: nil,
+          errors: [ "You can only update housework from your family" ]
+        }
+      end
+
+      # Check if housework is committed and cannot be updated
+      if housework.committed?
+        return {
+          housework: nil,
+          errors: [ "Cannot update committed housework" ]
+        }
+      end
+
+      # Check authorization: owner or admin can update
+      unless current_user.role == "admin" || housework.suggested_by_id == current_user.id
+        return {
+          housework: nil,
+          errors: [ "You can only update housework you created or must be an administrator" ]
+        }
+      end
+
+      # Only admins can set point and committed fields
+      if (attributes[:point].present? || attributes[:committed].present?) && current_user.role != "admin"
+        return {
+          housework: nil,
+          errors: [ "Only administrators can set point and committed fields" ]
+        }
+      end
+
+      # Filter out nil values to only update provided attributes
+      update_attributes = attributes.compact
+
+      if housework.update(update_attributes)
+        {
+          housework: housework,
+          errors: []
+        }
+      else
+        {
+          housework: nil,
+          errors: housework.errors.full_messages
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/update_housework_mutation.rb
+++ b/app/graphql/mutations/update_housework_mutation.rb
@@ -40,8 +40,8 @@ module Mutations
         }
       end
 
-      # Check if housework is committed and cannot be updated
-      if housework.committed?
+      # Check if housework is committed and cannot be updated (except for admins)
+      if housework.committed? && current_user.role != "admin"
         return {
           housework: nil,
           errors: [ "Cannot update committed housework" ]

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,6 +2,11 @@
 
 module Types
   class MutationType < Types::BaseObject
+    # Housework mutations
+    field :create_housework, mutation: Mutations::CreateHouseworkMutation
+    field :update_housework, mutation: Mutations::UpdateHouseworkMutation
+    field :delete_housework, mutation: Mutations::DeleteHouseworkMutation
+
     # TODO: remove me
     field :test_field, String, null: false,
       description: "An example field added by the generator"

--- a/spec/graphql/mutations/housework_mutations_spec.rb
+++ b/spec/graphql/mutations/housework_mutations_spec.rb
@@ -245,18 +245,19 @@ RSpec.describe 'Housework GraphQL Mutations', type: :request do
           expect(data['housework']['committed']).to eq(true)
         end
 
-        it 'cannot update committed housework even as admin' do
+        it 'can update committed housework as admin' do
           variables = {
             id: committed_housework.id,
-            title: 'Admin Trying to Update Committed'
+            title: 'Admin Updated Committed Housework'
           }
 
           result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
 
           expect(result['errors']).to be_nil
           data = result['data']['updateHousework']
-          expect(data['errors']).to include('Cannot update committed housework')
-          expect(data['housework']).to be_nil
+          expect(data['errors']).to be_empty
+          expect(data['housework']['title']).to eq('Admin Updated Committed Housework')
+          expect(data['housework']).not_to be_nil
         end
       end
     end
@@ -379,15 +380,19 @@ RSpec.describe 'Housework GraphQL Mutations', type: :request do
         expect(housework.deleted_at).not_to be_nil
       end
 
-      it 'cannot delete committed housework even as admin' do
+      it 'can delete committed housework as admin' do
         variables = { id: committed_housework.id }
 
         result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
 
         expect(result['errors']).to be_nil
         data = result['data']['deleteHousework']
-        expect(data['errors']).to include('Cannot delete committed housework')
-        expect(data['success']).to eq(false)
+        expect(data['errors']).to be_empty
+        expect(data['success']).to eq(true)
+
+        # Verify soft delete
+        committed_housework.reload
+        expect(committed_housework.deleted_at).not_to be_nil
       end
     end
 

--- a/spec/graphql/mutations/housework_mutations_spec.rb
+++ b/spec/graphql/mutations/housework_mutations_spec.rb
@@ -1,0 +1,448 @@
+require 'rails_helper'
+
+RSpec.describe 'Housework GraphQL Mutations', type: :request do
+  include FactoryBot::Syntax::Methods
+
+  let(:family) { create(:family) }
+  let(:admin_user) { create(:user, family: family, role: :admin) }
+  let(:member_user) { create(:user, family: family, role: :member) }
+  let(:guest_user) { create(:user, family: family, role: :guest) }
+  let(:other_family) { create(:family) }
+  let(:other_user) { create(:user, family: other_family, role: :member) }
+  let(:user_without_family) { create(:user, family: nil) }
+
+  def execute_mutation(mutation_string, variables: {}, context: {})
+    IzanamiBackendSchema.execute(mutation_string, variables: variables, context: context)
+  end
+
+  describe 'createHousework mutation' do
+    let(:mutation) do
+      <<~GRAPHQL
+        mutation($title: String!, $description: String, $schedule: String, $point: Int, $committed: Boolean) {
+          createHousework(input: {
+            title: $title,
+            description: $description,
+            schedule: $schedule,
+            point: $point,
+            committed: $committed
+          }) {
+            housework {
+              id
+              familyId
+              title
+              description
+              schedule
+              suggestedBy {
+                id
+                name
+              }
+              point
+              committed
+            }
+            errors
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when user is authenticated and has a family' do
+      context 'as a member user' do
+        it 'creates housework with basic fields' do
+          variables = {
+            title: '新しい掃除',
+            description: 'テスト用の掃除',
+            schedule: '毎日'
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['createHousework']
+          expect(data['errors']).to be_empty
+          expect(data['housework']).not_to be_nil
+          expect(data['housework']['title']).to eq('新しい掃除')
+          expect(data['housework']['description']).to eq('テスト用の掃除')
+          expect(data['housework']['schedule']).to eq('毎日')
+          expect(data['housework']['familyId']).to eq(family.id)
+          expect(data['housework']['suggestedBy']['id']).to eq(member_user.id)
+          expect(data['housework']['point']).to eq(0)
+          expect(data['housework']['committed']).to eq(false)
+        end
+
+        it 'cannot set point and committed fields' do
+          variables = {
+            title: '新しい掃除',
+            point: 20,
+            committed: true
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['createHousework']
+          expect(data['errors']).to include('Only administrators can set point and committed fields')
+          expect(data['housework']).to be_nil
+        end
+      end
+
+      context 'as an admin user' do
+        it 'creates housework with all fields including point and committed' do
+          variables = {
+            title: '管理者の掃除',
+            description: '管理者が作成',
+            point: 25,
+            committed: true
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['createHousework']
+          expect(data['errors']).to be_empty
+          expect(data['housework']).not_to be_nil
+          expect(data['housework']['title']).to eq('管理者の掃除')
+          expect(data['housework']['point']).to eq(25)
+          expect(data['housework']['committed']).to eq(true)
+        end
+      end
+    end
+
+    context 'when user is not authenticated' do
+      it 'returns authentication error' do
+        variables = { title: '認証なし掃除' }
+
+        result = execute_mutation(mutation, variables: variables)
+
+        expect(result['errors']).to be_nil
+        data = result['data']['createHousework']
+        expect(data['errors']).to include('You must be logged in to create housework')
+        expect(data['housework']).to be_nil
+      end
+    end
+
+    context 'when user has no family' do
+      it 'returns family assignment error' do
+        variables = { title: 'ファミリーなし掃除' }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: user_without_family })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['createHousework']
+        expect(data['errors']).to include('You must be assigned to a family to create housework')
+        expect(data['housework']).to be_nil
+      end
+    end
+
+    context 'with invalid data' do
+      it 'returns validation errors for missing title' do
+        variables = { title: '', description: '説明のみ' }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['createHousework']
+        expect(data['errors']).to include("タイトル を入力してください")
+        expect(data['housework']).to be_nil
+      end
+    end
+  end
+
+  describe 'updateHousework mutation' do
+    let!(:housework) { create(:housework, family: family, suggested_by: member_user, title: 'Original Title', point: 10, committed: false) }
+    let!(:committed_housework) { create(:housework, family: family, suggested_by: member_user, title: 'Committed Work', committed: true) }
+    let!(:other_user_housework) { create(:housework, family: family, suggested_by: admin_user, title: 'Admin Work') }
+
+    let(:mutation) do
+      <<~GRAPHQL
+        mutation($id: ID!, $title: String, $description: String, $schedule: String, $point: Int, $committed: Boolean) {
+          updateHousework(input: {
+            id: $id,
+            title: $title,
+            description: $description,
+            schedule: $schedule,
+            point: $point,
+            committed: $committed
+          }) {
+            housework {
+              id
+              title
+              description
+              schedule
+              point
+              committed
+            }
+            errors
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when updating own housework' do
+      context 'as the owner' do
+        it 'updates the housework successfully' do
+          variables = {
+            id: housework.id,
+            title: 'Updated Title',
+            description: 'Updated Description'
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['updateHousework']
+          expect(data['errors']).to be_empty
+          expect(data['housework']['title']).to eq('Updated Title')
+          expect(data['housework']['description']).to eq('Updated Description')
+        end
+
+        it 'cannot set admin-only fields' do
+          variables = {
+            id: housework.id,
+            title: 'Updated Title',
+            point: 50,
+            committed: true
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['updateHousework']
+          expect(data['errors']).to include('Only administrators can set point and committed fields')
+          expect(data['housework']).to be_nil
+        end
+
+        it 'cannot update committed housework' do
+          variables = {
+            id: committed_housework.id,
+            title: 'Trying to Update Committed'
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['updateHousework']
+          expect(data['errors']).to include('Cannot update committed housework')
+          expect(data['housework']).to be_nil
+        end
+      end
+
+      context 'as admin' do
+        it 'can update any housework with all fields' do
+          variables = {
+            id: housework.id,
+            title: 'Admin Updated Title',
+            point: 100,
+            committed: true
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['updateHousework']
+          expect(data['errors']).to be_empty
+          expect(data['housework']['title']).to eq('Admin Updated Title')
+          expect(data['housework']['point']).to eq(100)
+          expect(data['housework']['committed']).to eq(true)
+        end
+
+        it 'cannot update committed housework even as admin' do
+          variables = {
+            id: committed_housework.id,
+            title: 'Admin Trying to Update Committed'
+          }
+
+          result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
+
+          expect(result['errors']).to be_nil
+          data = result['data']['updateHousework']
+          expect(data['errors']).to include('Cannot update committed housework')
+          expect(data['housework']).to be_nil
+        end
+      end
+    end
+
+    context 'when updating other user\'s housework' do
+      it 'returns authorization error for non-admin' do
+        variables = {
+          id: other_user_housework.id,
+          title: 'Unauthorized Update'
+        }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['updateHousework']
+        expect(data['errors']).to include('You can only update housework you created or must be an administrator')
+        expect(data['housework']).to be_nil
+      end
+    end
+
+    context 'when user is not authenticated' do
+      it 'returns authentication error' do
+        variables = { id: housework.id, title: 'Unauthenticated Update' }
+
+        result = execute_mutation(mutation, variables: variables)
+
+        expect(result['errors']).to be_nil
+        data = result['data']['updateHousework']
+        expect(data['errors']).to include('You must be logged in to update housework')
+        expect(data['housework']).to be_nil
+      end
+    end
+
+    context 'when housework doesn\'t exist' do
+      it 'returns not found error' do
+        variables = { id: 'non-existent-id', title: 'Update Nothing' }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['updateHousework']
+        expect(data['errors']).to include('Housework not found')
+        expect(data['housework']).to be_nil
+      end
+    end
+
+    context 'when housework is from different family' do
+      let!(:other_family_housework) { create(:housework, family: other_family, suggested_by: other_user) }
+
+      it 'returns family restriction error' do
+        variables = { id: other_family_housework.id, title: 'Cross Family Update' }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['updateHousework']
+        expect(data['errors']).to include('You can only update housework from your family')
+        expect(data['housework']).to be_nil
+      end
+    end
+  end
+
+  describe 'deleteHousework mutation' do
+    let!(:housework) { create(:housework, family: family, suggested_by: member_user, title: 'To Delete', committed: false) }
+    let!(:committed_housework) { create(:housework, family: family, suggested_by: member_user, title: 'Committed Work', committed: true) }
+    let!(:other_user_housework) { create(:housework, family: family, suggested_by: admin_user, title: 'Admin Work') }
+
+    let(:mutation) do
+      <<~GRAPHQL
+        mutation($id: ID!) {
+          deleteHousework(input: { id: $id }) {
+            success
+            errors
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when deleting own housework' do
+      it 'soft deletes the housework successfully' do
+        variables = { id: housework.id }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to be_empty
+        expect(data['success']).to eq(true)
+
+        # Verify soft delete
+        housework.reload
+        expect(housework.deleted_at).not_to be_nil
+      end
+
+      it 'cannot delete committed housework' do
+        variables = { id: committed_housework.id }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to include('Cannot delete committed housework')
+        expect(data['success']).to eq(false)
+      end
+    end
+
+    context 'as admin' do
+      it 'can delete any non-committed housework' do
+        variables = { id: housework.id }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to be_empty
+        expect(data['success']).to eq(true)
+
+        # Verify soft delete
+        housework.reload
+        expect(housework.deleted_at).not_to be_nil
+      end
+
+      it 'cannot delete committed housework even as admin' do
+        variables = { id: committed_housework.id }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: admin_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to include('Cannot delete committed housework')
+        expect(data['success']).to eq(false)
+      end
+    end
+
+    context 'when deleting other user\'s housework' do
+      it 'returns authorization error for non-admin' do
+        variables = { id: other_user_housework.id }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to include('You can only delete housework you created or must be an administrator')
+        expect(data['success']).to eq(false)
+      end
+    end
+
+    context 'when user is not authenticated' do
+      it 'returns authentication error' do
+        variables = { id: housework.id }
+
+        result = execute_mutation(mutation, variables: variables)
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to include('You must be logged in to delete housework')
+        expect(data['success']).to eq(false)
+      end
+    end
+
+    context 'when housework doesn\'t exist' do
+      it 'returns not found error' do
+        variables = { id: 'non-existent-id' }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to include('Housework not found')
+        expect(data['success']).to eq(false)
+      end
+    end
+
+    context 'when housework is from different family' do
+      let!(:other_family_housework) { create(:housework, family: other_family, suggested_by: other_user) }
+
+      it 'returns family restriction error' do
+        variables = { id: other_family_housework.id }
+
+        result = execute_mutation(mutation, variables: variables, context: { current_user: member_user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['deleteHousework']
+        expect(data['errors']).to include('You can only delete housework from your family')
+        expect(data['success']).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Issue #12 の実装：houseworksテーブルについてのGraphQL mutationを実装
- CreateHouseworkMutation: 家事情報の新規登録
- UpdateHouseworkMutation: 家事情報の更新
- DeleteHouseworkMutation: 家事情報の削除（ソフトデリート）

## 実装した機能

### 1. 家事情報の新規登録 (CreateHouseworkMutation)
- ユーザーが所属するfamily_idの家事情報を登録
- point, committedは管理者(roleがadmin)のみが入力可能
- デフォルト値: point=0, committed=false

### 2. 家事情報の更新 (UpdateHouseworkMutation)
- 自分が作成した家事情報のみ更新可能
- または、管理者ユーザーが更新可能
- 管理者が承認(committedをtrueに設定)したら、自分が作成した家事情報であっても更新不可

### 3. 家事情報の削除 (DeleteHouseworkMutation)
- 自分が作成した家事情報のみ削除可能
- または、管理者ユーザーが削除可能
- 管理者が承認している場合は、自分が作成した家事情報であっても削除不可
- ソフトデリート（deleted_atタイムスタンプ設定）を使用

## 技術要件の実装
- ✅ GraphQL mutation として実装
- ✅ JWT認証によるユーザー権限チェック
- ✅ role-based access control (admin/member/guest)
- ✅ 適切なバリデーションとエラーハンドリング

## Test plan
- ✅ CreateHouseworkMutation の実装
- ✅ UpdateHouseworkMutation の実装
- ✅ DeleteHouseworkMutation の実装
- ✅ 権限チェックロジックの実装
- ✅ テストケースの作成（23個のテストケース、全てpass）
- ✅ bin/brakeman（セキュリティスキャン）pass
- ✅ bin/rubocop（コードスタイル）pass
- ✅ 全テストスイート pass（67 examples, 0 failures）

🤖 Generated with [Claude Code](https://claude.ai/code)