### PR TITLE
Add category column to houseworks table

### DIFF
--- a/app/graphql/mutations/create_housework_mutation.rb
+++ b/app/graphql/mutations/create_housework_mutation.rb
@@ -9,11 +9,12 @@ module Mutations
     argument :schedule, String, required: false, description: "Schedule information"
     argument :point, Integer, required: false, description: "Points for the housework (admin only)"
     argument :committed, Boolean, required: false, description: "Whether the housework is committed (admin only)"
+    argument :category, Types::HouseworkCategoryEnum, required: false, description: "Category of the housework"
 
     field :housework, Types::HouseworkType, null: true
     field :errors, [ String ], null: false
 
-    def resolve(title:, description: nil, schedule: nil, point: nil, committed: nil)
+    def resolve(title:, description: nil, schedule: nil, point: nil, committed: nil, category: nil)
       current_user = context[:current_user]
 
       unless current_user
@@ -41,6 +42,7 @@ module Mutations
       # Set default values for admin-only fields
       point = 0 if point.nil?
       committed = false if committed.nil?
+      category = "cooking" if category.nil?
 
       housework = Housework.new(
         family_id: current_user.family_id,
@@ -49,7 +51,8 @@ module Mutations
         schedule: schedule,
         suggested_by: current_user,
         point: point,
-        committed: committed
+        committed: committed,
+        category: category
       )
 
       if housework.save

--- a/app/graphql/mutations/update_housework_mutation.rb
+++ b/app/graphql/mutations/update_housework_mutation.rb
@@ -10,6 +10,7 @@ module Mutations
     argument :schedule, String, required: false, description: "Schedule information"
     argument :point, Integer, required: false, description: "Points for the housework (admin only)"
     argument :committed, Boolean, required: false, description: "Whether the housework is committed (admin only)"
+    argument :category, Types::HouseworkCategoryEnum, required: false, description: "Category of the housework"
 
     field :housework, Types::HouseworkType, null: true
     field :errors, [ String ], null: false

--- a/app/graphql/types/housework_category_enum.rb
+++ b/app/graphql/types/housework_category_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class HouseworkCategoryEnum < Types::BaseEnum
+    value "COOKING", "料理", value: "cooking"
+    value "CLEANING", "掃除", value: "cleaning"
+    value "SHOPPING", "買い物", value: "shopping"
+    value "LAUNDRY", "洗濯", value: "laundry"
+    value "OTHER", "その他", value: "other"
+  end
+end

--- a/app/graphql/types/housework_type.rb
+++ b/app/graphql/types/housework_type.rb
@@ -8,6 +8,7 @@ module Types
     field :suggested_by, Types::UserType, null: false
     field :point, Integer, null: false
     field :committed, Boolean, null: false
+    field :category, Types::HouseworkCategoryEnum, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/models/housework.rb
+++ b/app/models/housework.rb
@@ -2,6 +2,14 @@ class Housework < ApplicationRecord
   belongs_to :family
   belongs_to :suggested_by, class_name: "User"
 
+  enum :category, {
+    cooking: 0,
+    cleaning: 1,
+    shopping: 2,
+    laundry: 3,
+    other: 4
+  }
+
   validates :title, presence: true, length: { maximum: 200 }
   validates :description, length: { maximum: 500 }
   validates :schedule, length: { maximum: 100 }

--- a/db/migrate/20251005071241_add_category_to_houseworks.rb
+++ b/db/migrate/20251005071241_add_category_to_houseworks.rb
@@ -1,0 +1,5 @@
+class AddCategoryToHouseworks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :houseworks, :category, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_19_014501) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_05_071241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_19_014501) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "category", default: 0, null: false
     t.index ["deleted_at"], name: "index_houseworks_on_deleted_at"
     t.index ["family_id"], name: "index_houseworks_on_family_id"
     t.index ["suggested_by_id"], name: "index_houseworks_on_suggested_by_id"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -19,7 +19,8 @@ if User.none?
     description: 'リビングルーム全体の掃除機がけと拭き掃除を行う',
     schedule: '毎週土曜日の午前中',
     point: 15,
-    committed: false
+    committed: false,
+    category: :cleaning
   )
 
   puts "管理者ユーザーが作成されました: #{admin_user.email}"

--- a/spec/factories/houseworks.rb
+++ b/spec/factories/houseworks.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     schedule { "毎週土曜日" }
     point { 10 }
     committed { false }
+    category { :cleaning }
   end
 end

--- a/spec/models/housework_spec.rb
+++ b/spec/models/housework_spec.rb
@@ -55,6 +55,41 @@ RSpec.describe Housework, type: :model do
     end
   end
 
+  describe 'カテゴリー' do
+    let(:family) { create(:family) }
+    let(:user) { create(:user, family: family) }
+
+    it '料理カテゴリーが設定できる' do
+      housework = create(:housework, family: family, suggested_by: user, category: :cooking)
+      expect(housework.category).to eq('cooking')
+      expect(housework.cooking?).to be true
+    end
+
+    it '掃除カテゴリーが設定できる' do
+      housework = create(:housework, family: family, suggested_by: user, category: :cleaning)
+      expect(housework.category).to eq('cleaning')
+      expect(housework.cleaning?).to be true
+    end
+
+    it '買い物カテゴリーが設定できる' do
+      housework = create(:housework, family: family, suggested_by: user, category: :shopping)
+      expect(housework.category).to eq('shopping')
+      expect(housework.shopping?).to be true
+    end
+
+    it '洗濯カテゴリーが設定できる' do
+      housework = create(:housework, family: family, suggested_by: user, category: :laundry)
+      expect(housework.category).to eq('laundry')
+      expect(housework.laundry?).to be true
+    end
+
+    it 'その他カテゴリーが設定できる' do
+      housework = create(:housework, family: family, suggested_by: user, category: :other)
+      expect(housework.category).to eq('other')
+      expect(housework.other?).to be true
+    end
+  end
+
   describe 'アソシエーション' do
     it 'familyに紐付いている' do
       association = described_class.reflect_on_association(:family)


### PR DESCRIPTION
## 概要

- houseworksテーブルに5つのカテゴリー（料理、掃除、買い物、洗濯、その他）を持つcategoryカラムを追加しました
- Houseworkモデル及びGraphQL APIにcategoryフィールドを統合しました
- カテゴリー機能の包括的なテストを追加しました

## 変更内容

- categoryカラムを追加するマイグレーションを作成（integer型、デフォルト値あり）
- Rails 8の構文を使用してHouseworkモデルにenum定義を追加
- 日本語の説明付きでHouseworkCategoryEnum GraphQLタイプを作成
- CreateHouseworkMutationにcategory引数を追加（デフォルト値は"cooking"）
- UpdateHouseworkMutationにcategory引数を追加
- GraphQLスキーマのHouseworkTypeにcategoryフィールドを追加
- houseworkファクトリーにcategoryを含めるよう更新
- 5つのカテゴリー値すべてのテストを追加

## テスト計画

- [x] 既存のテストすべてが通過（72 examples, 0 failures）
- [x] カテゴリーenum機能のテストを5つ追加
- [x] セキュリティスキャン（brakeman）が警告なしで通過
- [x] リンター（rubocop）が違反なしで通過
- [x] マイグレーションが正常に実行

Resolves #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)