### PR TITLE
houseworksクエリにcategoryフィルター機能を追加

### DIFF
--- a/app/graphql/types/housework_filter_input_type.rb
+++ b/app/graphql/types/housework_filter_input_type.rb
@@ -4,5 +4,6 @@ module Types
     argument :suggested_by_id, ID, required: false, description: "Filter by suggester user ID"
     argument :point_min, Integer, required: false, description: "Minimum point value"
     argument :point_max, Integer, required: false, description: "Maximum point value"
+    argument :categories, [ Types::HouseworkCategoryEnum ], required: false, description: "Filter by categories (OR condition)"
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -79,6 +79,7 @@ module Types
         houseworks = houseworks.where(suggested_by_id: filter[:suggested_by_id]) if filter[:suggested_by_id].present?
         houseworks = houseworks.where(point: filter[:point_min]..) if filter[:point_min].present?
         houseworks = houseworks.where(point: ..filter[:point_max]) if filter[:point_max].present?
+        houseworks = houseworks.where(category: filter[:categories]) if filter[:categories].present?
       end
 
       if sort

--- a/spec/graphql/queries/housework_spec.rb
+++ b/spec/graphql/queries/housework_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
                 }
                 point
                 committed
+                category
                 createdAt
                 updatedAt
               }
@@ -166,6 +167,47 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
           expect(data['edges'].length).to eq(2)
           titles = data['edges'].map { |edge| edge['node']['title'] }
           expect(titles).to contain_exactly('掃除', '料理')
+        end
+      end
+
+      context 'with categories filter' do
+        let!(:cooking_housework) { create(:housework, family: family, suggested_by: user, title: '料理をする', category: :cooking) }
+        let!(:shopping_housework) { create(:housework, family: family, suggested_by: user, title: '買い物に行く', category: :shopping) }
+
+        it 'returns houseworks with a single category' do
+          result = execute_query(query,
+            variables: { familyId: family.id, filter: { categories: [ 'COOKING' ] } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data['edges'].length).to eq(1)
+          expect(data['edges'][0]['node']['title']).to eq('料理をする')
+        end
+
+        it 'returns houseworks with multiple categories (OR condition)' do
+          result = execute_query(query,
+            variables: { familyId: family.id, filter: { categories: [ 'COOKING', 'SHOPPING' ] } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data['edges'].length).to eq(2)
+          titles = data['edges'].map { |edge| edge['node']['title'] }
+          expect(titles).to contain_exactly('料理をする', '買い物に行く')
+        end
+
+        it 'returns empty when no houseworks match the categories' do
+          result = execute_query(query,
+            variables: { familyId: family.id, filter: { categories: [ 'LAUNDRY' ] } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data['edges'].length).to eq(0)
         end
       end
 


### PR DESCRIPTION
## 概要

houseworksテーブルに追加されたcategoryカラムに対応したGraphQL queryのフィルター機能を実装しました。

## 変更内容

### GraphQL Filter
- `HouseworkFilterInputType`に`categories`引数を追加
- 複数のカテゴリーをOR条件で指定可能（例: `categories: [COOKING, CLEANING]`で料理または掃除の家事を取得）

### Query Resolver
- `houseworks`クエリのリゾルバーでcategoryフィルタリングを実装
- `filter[:categories]`が指定された場合、該当するカテゴリーの家事のみを返す

### Tests
- GraphQLクエリに`category`フィールドを追加
- カテゴリーフィルターのテストを追加:
  - 単一カテゴリーでのフィルター
  - 複数カテゴリーでのフィルター（OR条件）
  - マッチしないカテゴリーでの検索

## クエリ例

```graphql
query {
  houseworks(familyId: "xxx", filter: { categories: [COOKING, SHOPPING] }) {
    edges {
      node {
        id
        title
        category
      }
    }
  }
}
```

## テスト結果

- RSpec: 75 examples, 0 failures
- Brakeman: 0 warnings
- Rubocop: 0 offenses

## 関連Issue

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)