### PR TITLE
houseworksクエリにtotalCountフィールドを追加 (#25)

### DIFF
--- a/app/graphql/types/housework_connection.rb
+++ b/app/graphql/types/housework_connection.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  class HouseworkConnection < Types::BaseConnection
+    edge_type(Types::HouseworkType.edge_type)
+
+    field :total_count, Integer, null: false, description: "Total number of houseworks matching the filter criteria"
+
+    def total_count
+      object.items.size
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -50,7 +50,7 @@ module Types
       argument :id, ID, required: true, description: "ID of the housework"
     end
 
-    field :houseworks, Types::HouseworkType.connection_type, null: false do
+    field :houseworks, Types::HouseworkConnection, null: false, connection: true do
       argument :family_id, ID, required: true, description: "ID of the family"
       argument :filter, Types::HouseworkFilterInputType, required: false, description: "Filter options"
       argument :sort, Types::HouseworkSortInputType, required: false, description: "Sort options"

--- a/spec/graphql/queries/housework_spec.rb
+++ b/spec/graphql/queries/housework_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
               startCursor
               endCursor
             }
+            totalCount
           }
         }
       GRAPHQL
@@ -127,6 +128,14 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
         expect(titles).to contain_exactly('掃除', '洗濯', '料理')
       end
 
+      it 'returns totalCount of all houseworks matching the criteria' do
+        result = execute_query(query, variables: { familyId: family.id }, context: { current_user: user })
+
+        expect(result['errors']).to be_nil
+        data = result['data']['houseworks']
+        expect(data['totalCount']).to eq(3)
+      end
+
       context 'with committed filter' do
         it 'returns only committed houseworks' do
           result = execute_query(query,
@@ -139,6 +148,17 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
           expect(data['edges'].length).to eq(1)
           expect(data['edges'][0]['node']['title']).to eq('洗濯')
           expect(data['edges'][0]['node']['committed']).to eq(true)
+        end
+
+        it 'returns correct totalCount with filter' do
+          result = execute_query(query,
+            variables: { familyId: family.id, filter: { committed: true } },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data['totalCount']).to eq(1)
         end
       end
 
@@ -342,6 +362,18 @@ RSpec.describe 'Housework GraphQL Queries', type: :request do
           expect(data['pageInfo']['hasNextPage']).to eq(true)
           expect(data['pageInfo']['startCursor']).not_to be_nil
           expect(data['pageInfo']['endCursor']).not_to be_nil
+        end
+
+        it 'returns totalCount of all items even when paginated' do
+          result = execute_query(query,
+            variables: { familyId: family.id, first: 2 },
+            context: { current_user: user }
+          )
+
+          expect(result['errors']).to be_nil
+          data = result['data']['houseworks']
+          expect(data['edges'].length).to eq(2)
+          expect(data['totalCount']).to eq(5)
         end
 
         it 'returns next page with after parameter' do


### PR DESCRIPTION
## 概要

このPRは、`houseworks` GraphQLクエリのレスポンスに `totalCount` フィールドを追加し、フロントエンドでの適切なページネーションUI実装を可能にします。

Fixes #25

## 変更内容

- **`HouseworkConnection` タイプを作成**: `BaseConnection` を拡張し、`totalCount` フィールドを追加したカスタムコネクションタイプ
- **`houseworks` クエリを更新**: デフォルトのコネクションタイプの代わりに、新しい `HouseworkConnection` タイプを使用するように変更
- **包括的なテストを追加**: `totalCount` が正しく動作することを検証するテスト:
  - すべての家事の正しいカウントを返す
  - フィルタが適用された場合の正しいカウントを返す
  - ページネーションで結果が制限されている場合でも全体のカウントを返す

## 実装の詳細

`totalCount` フィールドは、コネクションオブジェクトの `object.items.size` を呼び出すことで、フィルタ条件に一致する家事の総数を返します。これにより、`first` や `after` などのページネーションパラメータが使用されている場合でも、クライアントはページネーションUIに必要な全体のカウントを受け取ることができます。

## クエリの例

```graphql
query {
  houseworks(familyId: "xxx", filter: { committed: true }, first: 10) {
    edges {
      node {
        id
        title
        ...
      }
    }
    pageInfo {
      hasNextPage
      hasPreviousPage
      startCursor
      endCursor
    }
    totalCount  # 新しいフィールド！
  }
}
```

## テスト計画

- [x] 既存のテストがすべて成功
- [x] `totalCount` フィールドの新しいテストが成功
- [x] `bin/brakeman` によるセキュリティチェックが成功（警告なし）
- [x] `bin/rubocop` によるリンターチェックが成功（違反なし）
- [x] フィルタありで `totalCount` が正しい値を返すことを確認
- [x] ページネーションありでも `totalCount` が全体のカウントを返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)